### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @sqrl-lang/everyone


### PR DESCRIPTION
This theoretically should make it so all folks in @sqrl-lang/everyone will get auto-added as reviewers for this repo. More info here: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners